### PR TITLE
Demonstrate that remove() does _not_ remove records from the database like destroy() does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        combination: ['v5', 'v6', 'v6 with TS']
+        combination: ['v5', 'v6']
     name: SQLite (${{ matrix.combination }})
     runs-on: ubuntu-latest
     env:
@@ -31,7 +31,7 @@ jobs:
       matrix:
         postgres-version: [9.5, 10] # Does not work with 12
         native: [true, false]
-        combination: ['v5', 'v6', 'v6 with TS']
+        combination: ['v5', 'v6']
     name: Postgres ${{ matrix.postgres-version }}${{ matrix.native && ' (native)' || '' }} (${{ matrix.combination }})
     runs-on: ubuntu-latest
     services:
@@ -63,7 +63,7 @@ jobs:
         db:
           - '{ name: "MySQL 5.7", image: "mysql:5.7", dialect: "mysql" }'
           - '{ name: "MariaDB 10.3", image: "mariadb:10.3", dialect: "mariadb" }'
-        combination: ['v5', 'v6', 'v6 with TS']
+        combination: ['v5', 'v6']
     name: ${{ fromJson(matrix.db).name }} (${{ matrix.combination }})
     runs-on: ubuntu-latest
     services:
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         mssql-version: [2017, 2019]
-        combination: ['v5', 'v6', 'v6 with TS']
+        combination: ['v5', 'v6']
     name: MSSQL ${{ matrix.mssql-version }} (${{ matrix.combination }})
     runs-on: ubuntu-latest
     services:

--- a/src/sscce.js
+++ b/src/sscce.js
@@ -57,8 +57,8 @@ module.exports = async function() {
   const rolesToBeRemoved = await user.getRoles()
   expect(rolesToBeRemoved).to.have.length(2, 'User has roles')
 
-  await user.removeRoles(rolesToBeRemoved)
-  //await Promise.all(rolesToBeRemoved.map(role => role.destroy()))
+  //await user.removeRoles(rolesToBeRemoved)
+  await Promise.all(rolesToBeRemoved.map(role => role.destroy()))
 
   expect(await user.getRoles()).to.have.length(0, 'User has no roles')
   expect(await Role.findAll()).to.have.length(0, 'Roles removed from database')


### PR DESCRIPTION
https://github.com/sequelize/sequelize/issues/6926 is explicitly about _destroying_ the associated records, rather than just disassociating them (setting their association ids to null):

> any possible that I can delete associations, not just SET NULL?

A solution was provided that accomplishes this:
```
Promise.all(user.roles.map(role => role.destroy()))
```
And then later a comment was added that offered an "improved" version that was exactly what OP was originally doing:
```
const rolesToBeRemoved = await user.getRoles()
await user.removeRoles(rolesToBeRemoved)
```

This does _not_ do the same thing, as this PR demonstrates. The first commit uses the "improved" `removeRoles()`, which fails its tests because the role records are still in the database. The second commit uses the original `destroy()` method, which works as expected.